### PR TITLE
G++ 4.8.2

### DIFF
--- a/json_adapter.h
+++ b/json_adapter.h
@@ -254,34 +254,6 @@ inline void stream(Adapter& adapter,const std::string& /*key*/,T& value,bool mor
 	}
 }
 
-//-----------------------------------------------------------------------------
-// serialize a vector of T.
-template <typename T>
-inline void stream(Adapter& adapter,const std::string& key,std::vector<T>& value,bool more)
-{
-	// https://github.com/g40/esj/pull/2/files
-
-	// yack. Now there is a reason why this approach was chosen. The usual (and in my
-	// opinion better) way to do this is to have a number of suitably overloaded
-	// template functions. However so doing can be ambiguous given that we *only*
-	// want C++ strings and primitive bool/int/float. The resultant explosion of
-	// interfaces makes things far less clear
-	bool json_primitive = (std::is_same<T,std::wstring>::value || 
-						std::is_same<T,std::string>::value ||
-						std::is_integral<T>::value ||
-						std::is_floating_point<T>::value);
-	// but we _can_ make the implementation a little easier to follow by doing this:
-	if (json_primitive)
-	{
-		stream_primitives<T>(adapter,key,value,more);
-	}
-	else
-	{
-		stream_classes<T>(adapter,key,value,more);
-	}
-		//
-	// https://github.com/g40/esj/pull/2/files
-}
 
 //-----------------------------------------------------------------------------
 // this means we get (with quotes removed for clarity) vectors of string etc
@@ -474,6 +446,36 @@ inline void stream_classes(Adapter& adapter,const std::string& key,std::vector<T
 			}
 		}
 	};
+
+//-----------------------------------------------------------------------------
+// serialize a vector of T.
+template <typename T>
+inline void stream(Adapter& adapter,const std::string& key,std::vector<T>& value,bool more)
+{
+	// https://github.com/g40/esj/pull/2/files
+
+	// yack. Now there is a reason why this approach was chosen. The usual (and in my
+	// opinion better) way to do this is to have a number of suitably overloaded
+	// template functions. However so doing can be ambiguous given that we *only*
+	// want C++ strings and primitive bool/int/float. The resultant explosion of
+	// interfaces makes things far less clear
+	bool json_primitive = (std::is_same<T,std::wstring>::value || 
+						std::is_same<T,std::string>::value ||
+						std::is_integral<T>::value ||
+						std::is_floating_point<T>::value);
+	// but we _can_ make the implementation a little easier to follow by doing this:
+	if (json_primitive)
+	{
+		stream_primitives<T>(adapter,key,value,more);
+	}
+	else
+	{
+		stream_classes<T>(adapter,key,value,more);
+	}
+		//
+	// https://github.com/g40/esj/pull/2/files
+}
+
 }	// JSON
 
 

--- a/json_lexer.h
+++ b/json_lexer.h
@@ -224,7 +224,7 @@ inline void throw_if(ISource* pSource,bool condition,std::string msg)
 	{
 		Chordia::stringer sb;
 		sb << "Error (" << (pSource ? pSource->Line() : 0) << ':' << (pSource ? pSource->Col() : 0) << ") " << msg;
-		//__THROW(json_exception(sb.c_str()));
+		__PLATFORM_THROW(json_exception(sb.c_str()));
 	}
 }
 
@@ -234,7 +234,7 @@ inline void throw_if(bool condition,Chordia::stringer& msg)
 {
 	if (condition == true)
 	{
-		//__THROW(json_exception(msg.c_str()));
+		__PLATFORM_THROW(json_exception(msg.c_str()));
 	}
 }
 

--- a/json_lexer.h
+++ b/json_lexer.h
@@ -224,7 +224,7 @@ inline void throw_if(ISource* pSource,bool condition,std::string msg)
 	{
 		Chordia::stringer sb;
 		sb << "Error (" << (pSource ? pSource->Line() : 0) << ':' << (pSource ? pSource->Col() : 0) << ") " << msg;
-		__THROW(json_exception(sb.c_str()));
+		//__THROW(json_exception(sb.c_str()));
 	}
 }
 
@@ -234,7 +234,7 @@ inline void throw_if(bool condition,Chordia::stringer& msg)
 {
 	if (condition == true)
 	{
-		__THROW(json_exception(msg.c_str()));
+		//__THROW(json_exception(msg.c_str()));
 	}
 }
 

--- a/json_reader.h
+++ b/json_reader.h
@@ -106,7 +106,7 @@ namespace JSON
 			{
 				Chordia::stringer sb;
 				sb << "Error (" << m_pScanner->Line() << ':' << m_pScanner->Col() << ") " << msg;
-				__THROW(json_exception(sb.c_str()));
+				__PLATFORM_THROW(json_exception(sb.c_str()));
 			}
 		}
 

--- a/platform_selector.h
+++ b/platform_selector.h
@@ -101,7 +101,7 @@ typedef int64_t int_size;
 // apologies for the macros once more ...?
 #define _IS_NAN(arg) std::isnan(arg)
 #define _IS_INF(arg) std::isinf(arg)
-
+#define __PLATFORM_THROW(arg) throw (arg)
 //
 typedef int64_t int_size;
 

--- a/platform_selector.h
+++ b/platform_selector.h
@@ -70,7 +70,7 @@ namespace std
 // apologies for the macros once more ...?
 #define _IS_NAN(arg) std::isnan(arg)
 #define _IS_INF(arg) std::isinf(arg)
-#define __THROW(arg) throw arg
+#define __PLATFORM_THROW(arg) throw (arg)
 	
 }
 
@@ -90,7 +90,7 @@ typedef int64_t int_size;
 // apologies for the macros once more ...?
 #define _IS_NAN(arg) isnan(arg)
 #define _IS_INF(arg) isinf(arg)
-#define __THROW(arg) throw arg
+#define __PLATFORM_THROW(arg) throw (arg)
 
 // g++
 #elif defined(__GNUG__)
@@ -113,7 +113,7 @@ typedef int64_t int_size;
 // apologies for the macros once more ...?
 #define _IS_NAN(arg) isnan(arg)
 #define _IS_INF(arg) isinf(arg)
-#define __THROW(arg) throw arg
+#define __PLATFORM_THROW(arg) throw (arg)
 //
 typedef int32_t int_size;
 


### PR DESCRIPTION
g++ did not like forward use of stream_primitive and steam_atomic. move order.
g++ did not like lack of parentheses around `throw arg`

N.B. g++ users. tested on 4.8.2 requires -std=c++11
